### PR TITLE
Fix guardian power key bindings

### DIFF
--- a/ValheimLegends.cs
+++ b/ValheimLegends.cs
@@ -1842,7 +1842,7 @@ namespace ValheimLegends
         {
             public static bool Prefix(Player __instance)
             {
-                if (ZInput.GetButtonDown("GPower") || ZInput.GetButtonDown("JoyGPower"))
+                if (ZInput.GetButtonDown("GP") || ZInput.GetButtonDown("JoyGP"))
                 {
                     ValheimLegends.shouldUseGuardianPower = true;
                 }


### PR DESCRIPTION
The key binding names changed which prevented `ValheimLegends.shouldUseGuardianPower` from being set to `true` so that players were unable to use the guardian power after using class abilities.