### PR TITLE
Update ValheimLegends.cs

### DIFF
--- a/ValheimLegends.cs
+++ b/ValheimLegends.cs
@@ -1842,7 +1842,7 @@ namespace ValheimLegends
         {
             public static bool Prefix(Player __instance)
             {
-                if (ZInput.GetButtonDown("GPower") || ZInput.GetButtonDown("JoyGPower"))
+                if (ZInput.GetButtonDown("GP") || ZInput.GetButtonDown("JoyGP"))
                 {
                     ValheimLegends.shouldUseGuardianPower = true;
                 }


### PR DESCRIPTION
Changed Guardian Power binding from old 'GPower' to new 'GP' name to fix issue - unable to activate Guardian Power.